### PR TITLE
Added definition for Privilege Escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,4 @@
-# workplace-communication-activity
-#📘 Pseudo Code: Programming Firm Communication Using Operational Terms
+## Additional Term
 
-# identify and fix the original operational term for each scrambled word
-
-BEGIN
-    FUNCTION MorningSyncMeeting()
-        
-        PRINT "Team Lead: Good morning team, let's review current system status."
-
-        PRINT "SysAdmin: ALERT! The email server is NWDO since 2:00 AM."
-        PRINT "Developer A: Understood. Let me GNPI the infra team for support."
-
-        PRINT "QA Tester: There’s a GUB affecting the checkout button on mobile."
-        PRINT "Developer B: I saw that too. Let's reproduce it in the OXNSADB environment first."
-
-        PRINT "Team Lead: Confirm this is not affecting DORP?"
-        PRINT "QA Tester: Correct, DORP is stable. Only OXNSADB shows the issue."
-
-        PRINT "Developer A: I’ve written a XTFIOTH and pushed it to the staging branch."
-        PRINT "SysAdmin: Great. We’ll apply the THCAP to the live server after approval."
-
-        PRINT "Security Analyst: Also, I found traces of a RKOABODC in the old admin panel."
-        PRINT "Developer B: That panel is a CYELGA module. We should plan to retire it soon."
-
-        PRINT "Team Lead: Excellent updates. Continue monitoring and GNPI me for urgent issues."
-    END FUNCTION
-
-    CALL MorningSyncMeeting()
-END
+**Privilege Escalation**  
+Privilege escalation is a situation in which a user gains higher access rights than originally authorized. This can allow attackers to take full control of a system and perform unauthorized actions.


### PR DESCRIPTION
This pull request adds a definition for the term "Privilege Escalation" to improve the completeness of the README documentation.

This term is important in cybersecurity as it explains how attackers can gain higher access rights and compromise systems.

Kindly review the changes and feel free to ping me if further clarification is needed.