### PR TITLE
Correct THCAP to PATCH in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ BEGIN
         PRINT "QA Tester: Correct, DORP is stable. Only OXNSADB shows the issue."
 
         PRINT "Developer A: I’ve written a XTFIOTH and pushed it to the staging branch."
-        PRINT "SysAdmin: Great. We’ll apply the THCAP to the live server after approval."
+        PRINT "SysAdmin: Great. We’ll apply the PATCH to the live server after approval."
 
         PRINT "Security Analyst: Also, I found traces of a RKOABODC in the old admin panel."
         PRINT "Developer B: That panel is a CYELGA module. We should plan to retire it soon."


### PR DESCRIPTION
This PR corrects the operational term "THCAP" to "PATCH" in the README.