### PR TITLE
Added definition for "patch" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ BEGIN
 
     CALL MorningSyncMeeting()
 END
+
+### Additional Term
+
+**Patch** – A small software update released to fix a bug or security issue without changing the entire system.


### PR DESCRIPTION
This PR updates the README to include a missing term definition for "patch," which is commonly used in workplace communication when discussing bug fixes and updates.