### PR TITLE
Added definition for 'Hacking' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,7 @@ BEGIN
     END FUNCTION
 
     CALL MorningSyncMeeting()
+
+    **Hacking:** The unauthorized access to or manipulation of a computer system, network, or data to bypass security controls.
+    
 END


### PR DESCRIPTION
This PR updates the README to include a missing term definition for 'Hacking'.